### PR TITLE
Rename plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-nomad-skeleton-driver-plugin
-wasmtime-driver
+build

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-PLUGIN_BINARY=build/wasmtime-driver
+PLUGIN_BINARY=build/wasm-task-driver
 export GO111MODULE=on
 
 default: build

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-Nomad Wasmtime Driver
+WASM Task Driver
 ==========
 
-This driver provides the ability to run WASM modules with Wasmtime runtime on
-Nomad.
+This driver provides the ability to run WASM modules with
+[Wasmtime](https://github.com/bytecodealliance/wasmtime-go) runtime on
+[Nomad](https://github.com/hashicorp/nomad).
 
 ## Example Job
 
@@ -16,7 +17,7 @@ job "sum" {
 
   group "sum" {
     task "sum" {
-      driver = "wasmtime"
+      driver = "wasm-task-driver"
 
       config {
         modulePath = "example/wasm-modules/sum.wasm"
@@ -51,7 +52,7 @@ Also make sure you use `go 1.21` or newer. After that you just need to execute
 the following commands:
 
 ```sh
-cd nomad-wasmtime-driver-plugin
+cd wasm-task-driver
 make build
 ```
 
@@ -91,8 +92,8 @@ make build
   * **enabled** - Defaults to `false`. Enables the ability to pass some data
     (e.g. string) to the WASM module buffer. Buffer must be created on the
     WASM module side.
-  * **size** - Defaults to `4096`. Helps to define the limits of the buffer
-    created in the WASM module.
+  * **size** - Defaults to `4096`. Defines the length of the buffer created
+    in the WASM module.
   * **inputValue** - Defines the value passed to the WASM module buffer.
   * **IOBufFuncName** - Defaults to `get_io_buffer_ptr`. Defines the name of the
     exported function in the WASM module that returns the address of the start
@@ -107,15 +108,15 @@ make build
   * **args** - Stores arguments that can be passed to the corresponding function
     (specified in `mainFuncName` parameter).
 
-## How To Start Nomad With Wasmtime Driver
+## How To Start Nomad With WASM Task Driver
 
 ### Local Development Setup
 
 ```sh
-# Build the Wasmtime Driver
+# Build the WASM Task Driver
 make build
 
-# Start Nomad with Wasmtime Driver
+# Start Nomad with WASM Task Driver
 nomad agent -dev -config=./example/config/agent.hcl -plugin-dir=$(pwd)/build/
 
 # Run Nomad job
@@ -142,7 +143,7 @@ nomad logs $(ALLOCATION_ID)
 
    ```vim
    ...
-   plugin "wasmtime-driver" {
+   plugin "wasm-task-driver" {
      config {
        cache {
          enabled = true
@@ -154,7 +155,7 @@ nomad logs $(ALLOCATION_ID)
          }
          preCache {
            enabled = false
-           modulesDir = "/nomad-wasmtime-driver-plugin/example/wasm-modules"
+           modulesDir = "/wasm-task-driver/example/wasm-modules"
          }
        }
      }

--- a/example/config/agent.hcl
+++ b/example/config/agent.hcl
@@ -1,7 +1,7 @@
 log_level = "TRACE"
 bind_addr = "0.0.0.0"
 
-plugin "wasmtime-driver" {
+plugin "wasm-task-driver" {
   config {
     cache {
       enabled = true
@@ -13,7 +13,7 @@ plugin "wasmtime-driver" {
       }
       preCache {
         enabled = false
-        modulesDir = "/home/dpovolotskii/git/nomad-wasmtime-driver-plugin/example/wasm-modules"
+        modulesDir = "/home/dpovolotskii/git/wasm-task-driver/example/wasm-modules"
       }
     }
   }

--- a/example/job/extra_args_job.nomad
+++ b/example/job/extra_args_job.nomad
@@ -4,10 +4,10 @@ job "extra_args_example" {
 
   group "extra_args_example" {
     task "sum-numbers" {
-      driver = "wasmtime"
+      driver = "wasm-task-driver"
 
       config {
-        modulePath = "/home/dpovolotskii/git/nomad-wasmtime-driver-plugin/example/wasm-modules/sum.wasm"
+        modulePath = "/home/dpovolotskii/git/wasm-task-driver/example/wasm-modules/sum.wasm"
         main {
           mainFuncName = "sum"
           args = [123456, 678910]

--- a/example/job/full_job.nomad
+++ b/example/job/full_job.nomad
@@ -4,10 +4,10 @@ job "full_example" {
 
   group "full_example" {
     task "up-string" {
-      driver = "wasmtime"
+      driver = "wasm-task-driver"
 
       config {
-        modulePath = "/home/dpovolotskii/git/nomad-wasmtime-driver-plugin/example/wasm-modules/upper.wasm"
+        modulePath = "/home/dpovolotskii/git/wasm-task-driver/example/wasm-modules/upper.wasm"
         ioBuffer {
           enabled = true
           size = 4096

--- a/example/job/simple_job.nomad
+++ b/example/job/simple_job.nomad
@@ -4,10 +4,10 @@ job "simple_example" {
 
   group "simple_example" {
     task "reverse-string" {
-      driver = "wasmtime"
+      driver = "wasm-task-driver"
 
       config {
-        modulePath = "/home/dpovolotskii/git/nomad-wasmtime-driver-plugin/example/wasm-modules/buf_invertor.wasm"
+        modulePath = "/home/dpovolotskii/git/wasm-task-driver/example/wasm-modules/buf_invertor.wasm"
         ioBuffer {
           enabled = true
           inputValue = "test_string"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module huawei.com/nomad-wasmtime-driver-plugin
+module huawei.com/wasm-task-driver
 
 go 1.21
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/plugins"
 
-	"huawei.com/nomad-wasmtime-driver-plugin/wasmtime"
+	"huawei.com/wasm-task-driver/wasm"
 )
 
 func main() {
@@ -14,5 +14,5 @@ func main() {
 
 // factory returns a new instance of a nomad driver plugin.
 func factory(log hclog.Logger) interface{} {
-	return wasmtime.NewPlugin(log)
+	return wasm.NewPlugin(log)
 }

--- a/wasm/handle.go
+++ b/wasm/handle.go
@@ -1,4 +1,4 @@
-package wasmtime
+package wasm
 
 import (
 	"fmt"

--- a/wasm/state.go
+++ b/wasm/state.go
@@ -1,4 +1,4 @@
-package wasmtime
+package wasm
 
 import (
 	"sync"


### PR DESCRIPTION
Renaming plugin from nomad-wasmtime-driver-plugin to wasm-task-driver